### PR TITLE
Fix friend request query condition

### DIFF
--- a/cerebrate_bot.py
+++ b/cerebrate_bot.py
@@ -67,8 +67,7 @@ async def create_friend_request(requester_id: int, addressee_id: int) -> bool:
     try:
         # Check if friendship already exists
         existing = supabase.table("friendships").select("*").or_(
-            f"and(requester_id.eq.{requester_id},addressee_id.eq.{addressee_id}),"
-            f"and(requester_id.eq.{addressee_id},addressee_id.eq.{requester_id})"
+            f"and(requester_id.eq.{requester_id},addressee_id.eq.{addressee_id}),and(requester_id.eq.{addressee_id},addressee_id.eq.{requester_id})"
         ).execute()
         
         if existing.data:


### PR DESCRIPTION
## Summary
- check existing friendships with a single `.or_()` condition

## Testing
- `python -m py_compile cerebrate_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_683f59c7b7208329b3d736d5cf5f687e